### PR TITLE
feat: delete the trigger label before updating the branch

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,28 @@ inputs:
       You can specify multiple pull request numbers separated by commas or newlines.
     required: false
     default: ${{github.event.issue.number}}
+
+  label_name:
+    description: |
+      Label name to trigger the action.
+    required: false
+    default: ${{github.event.label.name}}
+  label_description:
+    description: |
+      Label description to trigger the action.
+    required: false
+    default: ${{github.event.label.description}}
+  delete_label:
+    description: |
+      Either true or false. If true, the label is deleted.
+    required: false
+    default: "true"
+  github_token_to_delete_label:
+    description: |
+      GitHub token to delete the label.
+    required: false
+    default: "${{github.token}}"
+
 runs:
   using: node24
   main: dist/index.js

--- a/src/delete_label.ts
+++ b/src/delete_label.ts
@@ -1,0 +1,40 @@
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+
+export const deleteLabel = async (labelName: string) => {
+  if (!core.getBooleanInput("delete_label")) {
+    return;
+  }
+  const repository = `${github.context.repo.owner}/${github.context.repo.repo}`;
+  const token = core.getInput("github_token_to_delete_label");
+  if (!token) {
+    core.warning(
+      `Failed to delete a label of ${repository}: github_token_to_delete_label is required`,
+    );
+    return;
+  }
+  if (!labelName) {
+    core.warning(
+      `Failed to delete a label of ${repository}: label_name is required`,
+    );
+    return;
+  }
+  try {
+    await _deleteLabel(token, labelName);
+  } catch (error) {
+    core.warning(
+      `Failed to delete a label ${labelName} of ${repository}: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
+    );
+  }
+};
+
+const _deleteLabel = async (token: string, labelName: string) => {
+  const octokit = github.getOctokit(token);
+  const param = {
+    owner: github.context.repo.owner,
+    repo: github.context.repo.repo,
+    name: labelName,
+  };
+  core.info(`Deleting a label ${labelName} of ${param.owner}/${param.repo}`);
+  await octokit.rest.issues.deleteLabel(param);
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 import * as githubAppToken from "@suzuki-shunsuke/github-app-token";
+import { deleteLabel } from "./delete_label";
 
 const parseLabelDescription = (
   description: string,
@@ -20,10 +21,17 @@ const parseLabelDescription = (
 };
 
 export const action = async () => {
-  const labelDescription = github.context.payload.label?.description;
+  const labelDescription = core.getInput("label_description", {
+    required: false,
+  });
+  const labelName = core.getInput("label_name", {
+    required: false,
+  });
   if (!labelDescription) {
-    throw new Error("Label description is not found in the event payload");
+    throw new Error("Label description is required");
   }
+
+  await deleteLabel(labelName);
 
   const { owner, repo, prNumber } = parseLabelDescription(labelDescription);
 


### PR DESCRIPTION
## Summary

Adds a feature to delete the label that triggered the action before the branch update runs, and makes the label inputs explicit on the action.

The deletion currently happens before the branch update for implementation simplicity. Ideally it would run in parallel with the update, but that complicates the code, so for now it is sequenced before.

## Changes

### `action.yaml` — four new inputs

- `label_name` — label name that triggered the action. Defaults to `${{github.event.label.name}}`.
- `label_description` — label description that triggered the action. Defaults to `${{github.event.label.description}}`. Used to derive `owner/repo/pr_number`.
- `delete_label` — `"true"`/`"false"` toggle. When `true` (default), the label is deleted before the action proceeds.
- `github_token_to_delete_label` — token used to delete the label. Defaults to `${{github.token}}`. Kept separate from `app_id`/`app_private_key` because deletion targets the workflow's own repo, not the target repo.

### `src/server.ts`

- Read `label_description` and `label_name` via `core.getInput(...)` instead of pulling them directly from `github.context.payload.label`. The action.yaml defaults still source them from the event payload, so existing callers keep working, but callers can now override.
- Call `deleteLabel(labelName)` before parsing the description and creating the GitHub App token — i.e., before the branch update.
- Simplified the missing-description error message (`Label description is required`).

### `src/delete_label.ts` (new)

- `deleteLabel(labelName)` is a no-op when `delete_label` is `false`.
- If `github_token_to_delete_label` or `labelName` is missing, it emits a `core.warning` and returns — the action does not fail.
- Deletion targets the repo that runs the workflow (`github.context.repo.owner` / `.repo`), using `octokit.rest.issues.deleteLabel`.
- Any API error from `deleteLabel` is caught and logged via `core.warning` so a failed label cleanup doesn't fail the branch update.

## Test plan

- [ ] Trigger the action via a labeled event and confirm the label is deleted from the workflow's repo before the branch update runs.
- [ ] Set `delete_label: "false"` and confirm the label is retained.
- [ ] Omit `github_token_to_delete_label` (or pass an empty value) and confirm a warning is emitted instead of a hard failure.
- [ ] Confirm deletion failure (e.g., revoked token) only produces a warning and the branch update still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)