### PR TITLE
ci(security): use takumi guard for npm install

### DIFF
--- a/.github/workflows/create-pr-branch.yaml
+++ b/.github/workflows/create-pr-branch.yaml
@@ -14,10 +14,13 @@ on:
 jobs:
   create-pr-branch:
     uses: ./.github/workflows/wc-create-pr-branch.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
     with:
       version: pr/${{inputs.pr}}
       pr: ${{fromJSON(inputs.pr)}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,9 @@ jobs:
     uses: ./.github/workflows/wc-create-pr-branch.yaml
     with:
       version: latest
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ jobs:
     with:
       version: ${{inputs.tag}}
       pr: ${{inputs.pr}}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write

--- a/.github/workflows/wc-create-pr-branch.yaml
+++ b/.github/workflows/wc-create-pr-branch.yaml
@@ -17,6 +17,9 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 
 jobs:
   create-pr-branch:
@@ -25,6 +28,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # Required for OIDC
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -46,6 +50,9 @@ jobs:
           node-version-file: .node-version
           cache-dependency-path: package-lock.json
           cache: npm
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
       - run: npm ci
 
       - run: npm run lint

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,6 +1,10 @@
 name: test (workflow_call)
 permissions: {}
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   path-filter:
     timeout-minutes: 10
@@ -34,6 +38,9 @@ jobs:
     with:
       version: pr/${{github.event.pull_request.number}}
       pr: ${{github.event.pull_request.number}}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       pull-requests: write
+      id-token: write

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @jsr:registry=https://npm.jsr.io
+registry=https://npm.flatt.tech/


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://shisho.dev/docs/r/202604-takumi-guard-rate-limit/#getting-started-with-organization-usage) to authenticate npm installs against the private registry (`npm.flatt.tech`), mirroring csm-actions/securefix-action#668 (the same change applied to csm-actions/label-action).

## Changes

- **`.npmrc`** — point the npm registry at `https://npm.flatt.tech/` (in addition to the existing `@jsr` registry). This routes installs through Takumi Guard, which requires authentication.
- **`wc-create-pr-branch.yaml`** — the only workflow that runs `npm ci`:
  - Add `setup-takumi-guard-npm@v1.1.1` after `setup-node` and before `npm ci`.
  - Grant the job `id-token: write` for OIDC.
  - Declare `TAKUMI_GUARD_BOT_ID` as a required `workflow_call` secret.
- **Thread `TAKUMI_GUARD_BOT_ID`** through every caller and propagate `id-token: write`:
  - `workflow_call_test.yaml` (declares the secret, passes it to `create_pr_branch`)
  - `test.yaml`, `main.yaml`, `release.yaml`, `create-pr-branch.yaml`

`autofix.yaml` is unchanged: it runs aqua/pinact/nllint only and never installs npm dependencies, so it needs neither Takumi Guard nor an `.npmrc` restore step.

## Prerequisite

A repository/organization secret **`TAKUMI_GUARD_BOT_ID`** (the bot ID issued by Shisho Cloud) must be configured, otherwise OIDC authentication fails.

## Validation

- `ghalint run` passes.
- `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
